### PR TITLE
Make resourceUri optional; return token and secret if it's not specified

### DIFF
--- a/oauth1.js
+++ b/oauth1.js
@@ -5,8 +5,6 @@ const url = require('url')
 module.exports = oauth1
 
 function oauth1 (options = {}) {
-  if (!options.resourceUri) throw new Error('missing options.resourceUri')
-
   return wrap(options)
 }
 
@@ -14,7 +12,10 @@ function wrap (options) {
   return function () {
     const oa = new OAuth(...arguments)
 
-    return { auth: auth(oa), callback: callback(oa) }
+    return {
+      auth: auth(oa),
+      callback: callback(oa)
+     }
   }
 
   function getRequestToken (oa, cb) {
@@ -37,19 +38,24 @@ function wrap (options) {
           urlParts.query.oauth_verifier,
           (err, token, secret, result) => {
             if (err) return oauthError(err)
-            oa.get(
-              options.resourceUri,
-              token,
-              secret,
-              (err, data) => {
-                if (err) return oauthError(err)
-                try {
-                  cb(null, JSON.parse(data))
-                } catch (err) {
-                  oauthError(err)
+
+            if (options.resourceUri) {
+              oa.get(
+                options.resourceUri,
+                token,
+                secret,
+                (err, data) => {
+                  if (err) return oauthError(err)
+                  try {
+                    cb(null, JSON.parse(data))
+                  } catch (err) {
+                    oauthError(err)
+                  }
                 }
-              }
-            )
+              )
+            } else {
+              cb(null, {token, secret})
+            }
           }
         )
       })

--- a/oauth2.js
+++ b/oauth2.js
@@ -5,7 +5,6 @@ const url = require('url')
 module.exports = oauth2
 
 function oauth2 (options = {}) {
-  if (!options.resourceUri) throw new Error('missing options.resourceUri')
   if (!options.callbackUri) throw new Error('missing options.callbackUri')
   options.scope = options.scope || ''
   options.responseType = options.responseType || 'code'
@@ -43,18 +42,22 @@ function wrap (options) {
       oa.getOAuthAccessToken(urlParts.query.code, { redirect_uri: options.callbackUri, grant_type: options.grantType },
         (err, token) => {
           if (err) return oauthError(err)
-          oa.getProtectedResource(
-            options.resourceUri,
-            token,
-            (err, data) => {
-              if (err) return oauthError(err)
-              try {
-                cb(null, JSON.parse(data))
-              } catch (err) {
-                oauthError(err)
+          if (options.resourceUri) {
+            oa.getProtectedResource(
+              options.resourceUri,
+              token,
+              (err, data) => {
+                if (err) return oauthError(err)
+                try {
+                  cb(null, JSON.parse(data))
+                } catch (err) {
+                  oauthError(err)
+                }
               }
-            }
-          )
+            )
+          } else {
+            cb(null, {token})
+          }
         }
       )
     }


### PR DESCRIPTION
For scenarios where the profile is not required, but the oauth token and secret are required, this makes the `resourceUri` option optional; if it's not specified, the `callback` method's callback is called with the token and secret.

When `resourceUri` is specified, `callback` works as before, returning the contents of the `resourceUri`.

This scenario is important when oauth is used for authorizing and app to act on behalf of the user, rather than using it for authentication.

I use this to obtain the authorized token and secret from Twitter like this:

```js
    const twitter = oauth1({})(
      'https://api.twitter.com/oauth/request_token',
      'https://api.twitter.com/oauth/access_token',
      process.env.TWITTER_ID,
      process.env.TWITTER_SECRET,
      '1.0',
      'http://my-callback-url/',
      'HMAC-SHA1'
    )

    return {
      auth: cb =>
        twitter.auth((err, token) => {
          if (err) return cb(err)
          cb(null, 'https://twitter.com/oauth/authorize?oauth_token=' + token)
        }),
      callback: twitter.callback
    }
```
